### PR TITLE
Update prost to version 0.13.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ anyhow = "1.0.66"
 flate2 = "1.0.24"
 libc = "0.2.138"
 once_cell = "1.16.0"
-prost = { version = "0.11.3", features = ["no-recursion-limit"] }
+prost = { version = "0.13.1", features = ["no-recursion-limit"] }
 tempfile = "3.2.0"
 tikv-jemalloc-ctl = { version = "0.5.0", features = ["use_std"] }
 tracing = "0.1.37"


### PR DESCRIPTION
This is to satisfy Materialize's single-version policy for Rust dependencies.