### PR TITLE
Avoid unix-specific functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,6 @@
 use std::ffi::CString;
 
 use std::io::BufReader;
-use std::os::unix::ffi::OsStrExt;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -155,7 +154,7 @@ impl JemallocProfCtl {
     /// Dump a profile into a temporary file and return it.
     pub fn dump(&mut self) -> anyhow::Result<std::fs::File> {
         let f = NamedTempFile::new()?;
-        let path = CString::new(f.path().as_os_str().as_bytes().to_vec()).unwrap();
+        let path = CString::new(f.path().as_os_str().as_encoded_bytes()).unwrap();
 
         // SAFETY: "prof.dump" is documented as being writable and taking a C string as input:
         // http://jemalloc.net/jemalloc.3.html#prof.dump


### PR DESCRIPTION
Currently, building on windows doesn't work, due to the call to `OsStr::as_bytes`, which only exists on unix.

This PR works around this by calling `OsStr::as_encoded_bytes`. I think this is technically invalid when the path contains invalid surrogate pairs - but hopefully this shouldn't ever happen on the temporary directory path we're using (which will almost always be some variation of "C:\Windows\Temp" - a fully ascii path).