### PR TITLE
Fix pprof file export when running application by directly invoking ld.so

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["mappings", "capi", "util"]
+members = ["mappings", "capi", "util", "example"]
 
 [package]
 name = "jemalloc_pprof"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -9,4 +9,4 @@ jemalloc_pprof = { path = ".." }
 tokio = { version = "1", features = ["full"] }
 axum = "0.7.2"
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.5.4", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"] }
+tikv-jemallocator = { version = "0.6", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"] }


### PR DESCRIPTION
Hi, we use `rust-jemalloc-pprof` in our application and had some trouble that it required this patch for it to export a right pprof file.

We run our application with a command like below:
`ld.so --library-path ./dylib ./app`

In this case, `rust-jemalloc-pprof` cannot export a valid pprof file because it sets `ld.so` as the main program, but actually `./app` is the main program. So we're using this patch to avoid this problem, which is using `libc::dladdr` with a function pointer of itself to obtain the file path of the main program.

We understand that this is a rare case to run a program like this and this implementation is kind of a hack, which isn't the best thing to maintain. So please feel free to close this PR, but we wanted to know if there's any chance for this PR to get merged.

Finally, thank you for open sourcing this great library!