### PR TITLE
Mappings support for MacOS

### DIFF
--- a/mappings/Cargo.toml
+++ b/mappings/Cargo.toml
@@ -16,3 +16,6 @@ libc.workspace = true
 once_cell.workspace = true
 tracing.workspace = true
 util.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies.mach2]
+version = "0.4"


### PR DESCRIPTION
Support for retrieving the list of memory-mapped objects on MacOS.

I haven't changed the statement in the README about only supporting Linux. I don't know if there are other things on the list of missing functionality, but for what it's worth, I was able to generate a useful profile on MacOS with these changes.