### PR TITLE
Add `flamegraph` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ categories = [
 documentation = "https://docs.rs/jemalloc_pprof/latest/jemalloc_pprof/"
 homepage = "https://crates.io/crates/jemalloc_pprof"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [workspace.dependencies]
 anyhow = "1"
 flate2 = "1.0"
@@ -39,6 +42,7 @@ errno = "0.3"
 util = { path = "./util", version = "0.6", package = "pprof_util" }
 mappings = { path = "./mappings", version = "0.6" }
 backtrace = "0.3"
+inferno = "0.12"
 
 [dependencies]
 util.workspace = true
@@ -52,6 +56,7 @@ tempfile.workspace = true
 tokio.workspace = true
 
 [features]
+flamegraph = ["util/flamegraph"]
 symbolize = ["util/symbolize"]
 
 [dev-dependencies]

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -10,3 +10,6 @@ tokio = { version = "1", features = ["full"] }
 axum = "0.7.2"
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"] }
+
+[features]
+flamegraph = ["jemalloc_pprof/flamegraph"]

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -18,6 +18,13 @@ async fn main() {
 
     let app = axum::Router::new().route("/debug/pprof/heap", axum::routing::get(handle_get_heap));
 
+    // Add a flamegraph SVG route if enabled via `cargo run -F flamegraph`.
+    #[cfg(feature = "flamegraph")]
+    let app = app.route(
+        "/debug/pprof/heap/flamegraph",
+        axum::routing::get(handle_get_heap_flamegraph),
+    );
+
     // run our app with hyper, listening globally on port 3000
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
     axum::serve(listener, app).await.unwrap();
@@ -30,6 +37,23 @@ pub async fn handle_get_heap() -> Result<impl IntoResponse, (StatusCode, String)
         .dump_pprof()
         .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
     Ok(pprof)
+}
+
+#[cfg(feature = "flamegraph")]
+pub async fn handle_get_heap_flamegraph() -> Result<impl IntoResponse, (StatusCode, String)> {
+    use axum::body::Body;
+    use axum::http::header::CONTENT_TYPE;
+    use axum::response::Response;
+
+    let mut prof_ctl = jemalloc_pprof::PROF_CTL.as_ref().unwrap().lock().await;
+    require_profiling_activated(&prof_ctl)?;
+    let svg = prof_ctl
+        .dump_flamegraph()
+        .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))?;
+    Response::builder()
+        .header(CONTENT_TYPE, "image/svg+xml")
+        .body(Body::from(svg))
+        .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()))
 }
 
 /// Checks whether jemalloc profiling is activated an returns an error response if not.

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -17,6 +17,8 @@ anyhow.workspace = true
 num.workspace = true
 paste.workspace = true
 backtrace = { workspace = true, optional = true }
+inferno = { workspace = true, optional = true }
 
 [features]
+flamegraph = ["symbolize", "dep:inferno"]
 symbolize = ["dep:backtrace"]


### PR DESCRIPTION
This patch adds a `flamegraph` feature, which can generate interactive flamegraph SVGs using the [`inferno`](https://crates.io/crates/inferno) crate.

It adds a new method `dump_flamegraph()`, as well as `dump_flamegraph_with_options()` which takes a `FlamegraphOptions` (a re-export of `inferno::flamegraph::Options`). This works similarly to the `pprof-rs` CPU profiler.

It implies the `symbolize` feature from #22 which enables online profile symbolization.

Example flamegraph: [profile.svg.gz](https://github.com/user-attachments/files/18922366/profile.svg.gz) (download and open since GitHub breaks the interactive SVG)