### PR TITLE
Fix endpoint paths from /heap to /allocs in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ async fn main() {
     }
 
     let app = axum::Router::new()
-        .route("/debug/pprof/heap", axum::routing::get(handle_get_heap));
+        .route("/debug/pprof/allocs", axum::routing::get(handle_get_heap));
 
     // run our app with hyper, listening globally on port 3000
     let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
@@ -89,7 +89,7 @@ fn require_profiling_activated(prof_ctl: &jemalloc_pprof::JemallocProfCtl) -> Re
 Then running the application, we can capture a profile and view it the pprof toolchain.
 
 ```shell
-curl localhost:3000/debug/pprof/heap > heap.pb.gz
+curl localhost:3000/debug/pprof/allocs > heap.pb.gz
 pprof -http=:8080 heap.pb.gz
 ```
 
@@ -117,8 +117,8 @@ We can then adjust the example above to also emit a flamegraph SVG:
 #[tokio::main]
 async fn main() {
     let app = axum::Router::new()
-        .route("/debug/pprof/heap", axum::routing::get(handle_get_heap))
-        .route("/debug/pprof/heap/flamegraph", axum::routing::get(handle_get_heap_flamegraph));
+        .route("/debug/pprof/allocs", axum::routing::get(handle_get_heap))
+        .route("/debug/pprof/allocs/flamegraph", axum::routing::get(handle_get_heap_flamegraph));
     // ...
 }
 

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -16,12 +16,12 @@ async fn main() {
         v.push(i);
     }
 
-    let app = axum::Router::new().route("/debug/pprof/heap", axum::routing::get(handle_get_heap));
+    let app = axum::Router::new().route("/debug/pprof/allocs", axum::routing::get(handle_get_heap));
 
     // Add a flamegraph SVG route if enabled via `cargo run -F flamegraph`.
     #[cfg(feature = "flamegraph")]
     let app = app.route(
-        "/debug/pprof/heap/flamegraph",
+        "/debug/pprof/allocs/flamegraph",
         axum::routing::get(handle_get_heap_flamegraph),
     );
 


### PR DESCRIPTION
## Summary
- Updated all references from `/debug/pprof/heap` to `/debug/pprof/allocs` in README.md
- Updated endpoint paths in example/src/main.rs to match the correct API
- Fixed flamegraph endpoint from `/debug/pprof/heap/flamegraph` to `/debug/pprof/allocs/flamegraph`