### PR TITLE
chore: update dependency versions and remove unused entries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,16 +9,16 @@ edition = "2021"
 publish = true
 license = "Apache-2.0"
 authors = [
-  "Frederic Branczyk <frederic.branczyk@polarsignals.com>",
-  "Brennan Vincent <brennan.vincent@polarsignals.com>",
+    "Frederic Branczyk <frederic.branczyk@polarsignals.com>",
+    "Brennan Vincent <brennan.vincent@polarsignals.com>",
 ]
 repository = "https://github.com/polarsignals/rust-jemalloc-pprof"
 keywords = ["jemalloc", "pprof", "memory", "profiling", "observability"]
 categories = [
-  "development-tools",
-  "development-tools::profiling",
-  "development-tools::debugging",
-  "memory-management",
+    "development-tools",
+    "development-tools::profiling",
+    "development-tools::debugging",
+    "memory-management",
 ]
 documentation = "https://docs.rs/jemalloc_pprof/latest/jemalloc_pprof/"
 homepage = "https://crates.io/crates/jemalloc_pprof"
@@ -28,12 +28,12 @@ all-features = true
 
 [workspace.dependencies]
 anyhow = "1"
-flate2 = "1.0"
+flate2 = "1.1"
 libc = "0.2"
-once_cell = "1.19"
+once_cell = "1.21"
 prost = { version = "0.14", features = ["no-recursion-limit"] }
-tempfile = "3.11"
-tikv-jemalloc-ctl = { version = "0.6", features = ["use_std"] }
+tempfile = "3.27"
+tikv-jemalloc-ctl = { version = "0.7", features = ["use_std"] }
 tracing = "0.1"
 tokio = { version = "1", features = ["time", "sync"] }
 paste = "1.0"
@@ -60,8 +60,6 @@ flamegraph = ["util/flamegraph"]
 symbolize = ["util/symbolize"]
 
 [dev-dependencies]
-tikv-jemallocator = "0.6"
-axum = "0.8"
 # re-import tokio to enable all its features. This is required to
 # successfully compile the test snipptes that are part of the documentation
 tokio = { version = "1", features = ["full"] }

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -10,7 +10,6 @@ name = "jemalloc_pprof"
 [dependencies]
 libc.workspace = true
 util.workspace = true
-anyhow.workspace = true
 tempfile.workspace = true
 mappings.workspace = true
 errno.workspace = true

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -7,9 +7,9 @@ publish = false
 [dependencies]
 jemalloc_pprof = { path = ".." }
 tokio = { version = "1", features = ["full"] }
-axum = "0.8.1"
+axum = "0.8.9"
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.6", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"] }
+tikv-jemallocator = { version = "0.7", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"] }
 
 [features]
 flamegraph = ["jemalloc_pprof/flamegraph"]


### PR DESCRIPTION
- bump workspace dependencies to newer crate releases
- update example dependencies for axum and tikv-jemallocator
- remove unused anyhow and stale dev-dependency entries from Cargo manifests