### PR TITLE
chore: bump workspace to v0.9.0 and centralize package metadata

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,12 +1,12 @@
 name: test suite
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
   test:
     name: cargo test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - run: |
           sudo apt update

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,6 @@ version = "0.9.0"
 jemalloc_pprof = { path = ".", version = "0.9.0" }
 pprof_util = { path = "./util", version = "0.9.0" }
 mappings = { path = "./mappings", version = "0.9.0" }
-capi = { path = "./capi", version = "0.9.0" }
-rust-jemalloc-pprof-example = { path = "./example", version = "0.9.0" }
 anyhow = "1"
 axum = "0.8.9"
 backtrace = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,15 +4,16 @@ members = ["mappings", "capi", "util", "example"]
 [package]
 name = "jemalloc_pprof"
 description = "Convert jemalloc heap profiles to pprof to understand memory usage, fix memory leaks, and fix OOM Kills."
-version = "0.8.2"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 publish = true
-license = "Apache-2.0"
+license.workspace = true
 authors = [
     "Frederic Branczyk <frederic.branczyk@polarsignals.com>",
     "Brennan Vincent <brennan.vincent@polarsignals.com>",
 ]
-repository = "https://github.com/polarsignals/rust-jemalloc-pprof"
+repository.workspace = true
+rust-version.workspace = true
 keywords = ["jemalloc", "pprof", "memory", "profiling", "observability"]
 categories = [
     "development-tools",
@@ -26,26 +27,38 @@ homepage = "https://crates.io/crates/jemalloc_pprof"
 [package.metadata.docs.rs]
 all-features = true
 
+[workspace.package]
+edition = "2024"
+license = "Apache-2.0"
+repository = "https://github.com/polarsignals/rust-jemalloc-pprof"
+rust-version = "1.85.0"
+version = "0.9.0"
+
 [workspace.dependencies]
+jemalloc_pprof = { path = ".", version = "0.9.0" }
+pprof_util = { path = "./util", version = "0.9.0" }
+mappings = { path = "./mappings", version = "0.9.0" }
+capi = { path = "./capi", version = "0.9.0" }
+rust-jemalloc-pprof-example = { path = "./example", version = "0.9.0" }
 anyhow = "1"
+axum = "0.8.9"
+backtrace = "0.3"
+errno = "0.3"
 flate2 = "1.1"
+inferno = "0.12"
 libc = "0.2"
+num = "0.4"
 once_cell = "1.21"
+paste = "1.0"
 prost = { version = "0.14", features = ["no-recursion-limit"] }
 tempfile = "3.27"
+tikv-jemallocator = { version = "0.7" }
 tikv-jemalloc-ctl = { version = "0.7", features = ["use_std"] }
 tracing = "0.1"
 tokio = { version = "1", features = ["time", "sync"] }
-paste = "1.0"
-num = "0.4"
-errno = "0.3"
-util = { path = "./util", version = "0.8", package = "pprof_util" }
-mappings = { path = "./mappings", version = "0.7" }
-backtrace = "0.3"
-inferno = "0.12"
 
 [dependencies]
-util.workspace = true
+pprof_util.workspace = true
 mappings.workspace = true
 libc.workspace = true
 anyhow.workspace = true
@@ -56,12 +69,12 @@ tempfile.workspace = true
 tokio.workspace = true
 
 [features]
-flamegraph = ["util/flamegraph"]
-symbolize = ["util/symbolize"]
+flamegraph = ["pprof_util/flamegraph"]
+symbolize = ["pprof_util/symbolize"]
 
 [dev-dependencies]
 # re-import tokio to enable all its features. This is required to
 # successfully compile the test snipptes that are part of the documentation
-tokio = { version = "1", features = ["full"] }
-tikv-jemallocator = "0.7"
-axum = "0.8"
+tokio = { workspace = true, features = ["full"] }
+tikv-jemallocator = { workspace = true }
+axum = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ authors = [
     "Brennan Vincent <brennan.vincent@polarsignals.com>",
 ]
 repository.workspace = true
-rust-version.workspace = true
 keywords = ["jemalloc", "pprof", "memory", "profiling", "observability"]
 categories = [
     "development-tools",
@@ -31,7 +30,6 @@ all-features = true
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/polarsignals/rust-jemalloc-pprof"
-rust-version = "1.85.0"
 version = "0.9.0"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
+[![test suite](https://github.com/polarsignals/rust-jemalloc-pprof/actions/workflows/tests.yaml/badge.svg)](https://github.com/polarsignals/rust-jemalloc-pprof/actions/workflows/tests.yaml)
+[![Crates](https://img.shields.io/crates/v/jemalloc_pprof.svg)](https://crates.io/crates/jemalloc_pprof)
+[![Documentation](https://docs.rs/jemalloc_pprof/badge.svg)](https://docs.rs/jemalloc_pprof)
+[![dependency status](https://deps.rs/repo/github/polarsignals/rust-jemalloc-pprof/status.svg)](https://deps.rs/repo/github/polarsignals/rust-jemalloc-pprof)
 [![Discord](https://img.shields.io/discord/813669360513056790?label=Discord)](https://discord.gg/Qgh4c9tRCE)
 
 # rust-jemalloc-pprof
 
-A rust library to collect and convert Heap profiling data from the [jemalloc](https://jemalloc.net/) allocator and convert it to the [pprof](https://github.com/google/pprof/tree/main/proto) format.
+A rust library to collect and convert Heap profiling data from the [jemalloc](https://jemalloc.net/) allocator and
+convert it to the [pprof](https://github.com/google/pprof/tree/main/proto) format.
 
-To understand how to use this together with Polar Signals Cloud to continuously collect profiling data, refer to the [Use with Polar Signals Cloud](#use-with-polar-signals-cloud) section.
+To understand how to use this together with Polar Signals Cloud to continuously collect profiling data, refer to
+the [Use with Polar Signals Cloud](#use-with-polar-signals-cloud) section.
 
-This code was originally developed as part of [Materialize](https://github.com/MaterializeInc/materialize), and then in a collaboration extracted into this standalone library.
+This code was originally developed as part of [Materialize](https://github.com/MaterializeInc/materialize), and then in
+a collaboration extracted into this standalone library.
 
 ## Requirements
 
@@ -18,7 +25,9 @@ this library will not be useful.
 
 ## Usage
 
-Internally this library uses [`tikv-jemalloc-ctl`](https://docs.rs/tikv-jemalloc-ctl/latest/tikv_jemalloc_ctl/) to interact with jemalloc, so to use it, you must use the jemalloc allocator via the [`tikv-jemallocator`](https://crates.io/crates/tikv-jemallocator) library.
+Internally this library uses [`tikv-jemalloc-ctl`](https://docs.rs/tikv-jemalloc-ctl/latest/tikv_jemalloc_ctl/) to
+interact with jemalloc, so to use it, you must use the jemalloc allocator via the [
+`tikv-jemallocator`](https://crates.io/crates/tikv-jemallocator) library.
 
 When adding `tikv-jemallocator` as a dependency, make sure to enable the `profiling` feature.
 
@@ -28,7 +37,8 @@ When adding `tikv-jemallocator` as a dependency, make sure to enable the `profil
 tikv-jemallocator = { version = "0.6.0", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 ```
 
-> Note: We also recommend enabling the `unprefixed_malloc_on_supported_platforms` feature, not strictly necessary, but will influence the rest of the usage.
+> Note: We also recommend enabling the `unprefixed_malloc_on_supported_platforms` feature, not strictly necessary, but
+> will influence the rest of the usage.
 
 Then configure the global allocator and configure it with profiling enabled.
 
@@ -42,11 +52,15 @@ static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
 ```
 
-> If you do not use the `unprefixed_malloc_on_supported_platforms` feature, you have to name it `_rjem_malloc_conf` it instead of `malloc_conf`.
+> If you do not use the `unprefixed_malloc_on_supported_platforms` feature, you have to name it `_rjem_malloc_conf` it
+> instead of `malloc_conf`.
 
-2^19 bytes (512KiB) is the default configuration for the sampling period, but we recommend being explicit. To understand more about jemalloc sampling check out the [detailed docs](https://github.com/jemalloc/jemalloc/blob/dev/doc_internal/PROFILING_INTERNALS.md#sampling) on it.
+2^19 bytes (512KiB) is the default configuration for the sampling period, but we recommend being explicit. To understand
+more about jemalloc sampling check out
+the [detailed docs](https://github.com/jemalloc/jemalloc/blob/dev/doc_internal/PROFILING_INTERNALS.md#sampling) on it.
 
-We recommend serving the profiling data on an HTTP server such as [axum](https://github.com/tokio-rs/axum), that could look like this, and we'll intentionally include a 4mb allocation to trigger sampling.
+We recommend serving the profiling data on an HTTP server such as [axum](https://github.com/tokio-rs/axum), that could
+look like this, and we'll intentionally include a 4mb allocation to trigger sampling.
 
 ```rust,ignore
 #[tokio::main]
@@ -93,7 +107,8 @@ curl localhost:3000/debug/pprof/allocs > heap.pb.gz
 pprof -http=:8080 heap.pb.gz
 ```
 
-> Note: if symbolization is not enabled, either `addr2line` or `llvm-addr2line` needs to be available in the path and pprof needs to be able to discover the respective debuginfos.
+> Note: if symbolization is not enabled, either `addr2line` or `llvm-addr2line` needs to be available in the path and
+> pprof needs to be able to discover the respective debuginfos.
 
 To generate symbolized profiles, enable the `symbolize` crate feature:
 
@@ -141,13 +156,20 @@ pub async fn handle_get_heap_flamegraph() -> Result<impl IntoResponse, (StatusCo
 
 ### Writeable temporary directory
 
-The way this library works is that it creates a new temporary file (in the [platform-specific default temp dir](https://docs.rs/tempfile/latest/tempfile/struct.NamedTempFile.html)), and instructs jemalloc to dump a profile into that file. Therefore the platform respective temporary directory must be writeable by the process. After reading and converting it to pprof, the file is cleaned up via the destructor. A single profile tends to be only a few kilobytes large, so it doesn't require a significant space, but it's non-zero and needs to be writeable.
+The way this library works is that it creates a new temporary file (in
+the [platform-specific default temp dir](https://docs.rs/tempfile/latest/tempfile/struct.NamedTempFile.html)), and
+instructs jemalloc to dump a profile into that file. Therefore the platform respective temporary directory must be
+writeable by the process. After reading and converting it to pprof, the file is cleaned up via the destructor. A single
+profile tends to be only a few kilobytes large, so it doesn't require a significant space, but it's non-zero and needs
+to be writeable.
 
 ## Use with Polar Signals Cloud
 
-Polar Signals Cloud allows continuously collecting heap profiling data, so you always have the right profiling data available, and don't need to search for the right data, you already have it!
+Polar Signals Cloud allows continuously collecting heap profiling data, so you always have the right profiling data
+available, and don't need to search for the right data, you already have it!
 
-Polar Signals Cloud supports anything in the pprof format, so a process exposing the above explained pprof endpoint, can then be scraped as elaborated in the [scraping docs](https://www.polarsignals.com/docs/setup-scraper).
+Polar Signals Cloud supports anything in the pprof format, so a process exposing the above explained pprof endpoint, can
+then be scraped as elaborated in the [scraping docs](https://www.polarsignals.com/docs/setup-scraper).
 
 ## Use from C or C++
 

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-rust-version.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -1,7 +1,10 @@
 [package]
 name = "capi"
-version = "0.7.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [lib]
 crate-type = ["cdylib"]
@@ -9,7 +12,7 @@ name = "jemalloc_pprof"
 
 [dependencies]
 libc.workspace = true
-util.workspace = true
+pprof_util.workspace = true
 tempfile.workspace = true
 mappings.workspace = true
 errno.workspace = true

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -1,20 +1,32 @@
-use std::ffi::CString;
-use std::io::BufReader;
-use std::mem::size_of_val;
-use std::os::unix::ffi::OsStrExt;
 use std::ptr::null_mut;
 
 use errno::{Errno, set_errno};
-use libc::{c_char, c_int, c_void, size_t};
+#[cfg(target_os = "linux")]
+use libc::c_char;
+#[cfg(target_os = "linux")]
+use libc::c_void;
+use libc::{c_int, size_t};
+#[cfg(target_os = "linux")]
 use mappings::MAPPINGS;
+#[cfg(target_os = "linux")]
 use pprof_util::parse_jeheap;
+#[cfg(target_os = "linux")]
+use std::ffi::CString;
+#[cfg(target_os = "linux")]
+use std::io::BufReader;
+#[cfg(target_os = "linux")]
+use std::mem::size_of_val;
+#[cfg(target_os = "linux")]
+use std::os::unix::ffi::OsStrExt;
+#[cfg(target_os = "linux")]
 use tempfile::NamedTempFile;
 
 pub const JP_SUCCESS: c_int = 0;
 pub const JP_FAILURE: c_int = -1;
 
+#[cfg(target_os = "linux")]
 #[link(name = "jemalloc")]
-extern "C" {
+unsafe extern "C" {
     // int mallctl(const char *name, void *oldp, size_t *oldlenp, void *newp, size_t newlen);
     fn mallctl(
         name: *const c_char,
@@ -27,8 +39,11 @@ extern "C" {
 
 enum Error {
     Io(std::io::Error),
+    #[cfg(target_os = "linux")]
     Mallctl(c_int),
+    #[cfg(target_os = "linux")]
     ParseProfile(),
+    UnsupportedPlatform,
 }
 
 impl From<std::io::Error> for Error {
@@ -37,6 +52,7 @@ impl From<std::io::Error> for Error {
     }
 }
 
+#[cfg(target_os = "linux")]
 fn dump_pprof_inner() -> Result<Vec<u8>, Error> {
     let f = NamedTempFile::new()?;
     let path = CString::new(f.path().as_os_str().as_bytes().to_vec()).unwrap();
@@ -63,6 +79,11 @@ fn dump_pprof_inner() -> Result<Vec<u8>, Error> {
     Ok(pprof)
 }
 
+#[cfg(not(target_os = "linux"))]
+fn dump_pprof_inner() -> Result<Vec<u8>, Error> {
+    Err(Error::UnsupportedPlatform)
+}
+
 /// Dump the current jemalloc heap profile in pprof format.
 ///
 /// This is intended to be called from C. A buffer is allocated
@@ -78,7 +99,7 @@ fn dump_pprof_inner() -> Result<Vec<u8>, Error> {
 ///
 /// You probably don't want to call this from Rust.
 /// Use the Rust API instead.
-#[no_mangle]
+#[unsafe(no_mangle)]
 pub unsafe extern "C" fn dump_jemalloc_pprof(buf_out: *mut *mut u8, n_out: *mut size_t) -> c_int {
     let buf = match dump_pprof_inner() {
         Ok(buf) => buf,
@@ -86,6 +107,7 @@ pub unsafe extern "C" fn dump_jemalloc_pprof(buf_out: *mut *mut u8, n_out: *mut 
             set_errno(Errno(e.raw_os_error().unwrap()));
             return JP_FAILURE;
         }
+        #[cfg(target_os = "linux")]
         Err(Error::Mallctl(i)) => {
             set_errno(Errno(i));
             return JP_FAILURE;

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -4,11 +4,11 @@ use std::mem::size_of_val;
 use std::os::unix::ffi::OsStrExt;
 use std::ptr::null_mut;
 
-use errno::{set_errno, Errno};
+use errno::{Errno, set_errno};
 use libc::{c_char, c_int, c_void, size_t};
 use mappings::MAPPINGS;
+use pprof_util::parse_jeheap;
 use tempfile::NamedTempFile;
-use util::parse_jeheap;
 
 pub const JP_SUCCESS: c_int = 0;
 pub const JP_FAILURE: c_int = -1;

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -43,6 +43,7 @@ enum Error {
     Mallctl(c_int),
     #[cfg(target_os = "linux")]
     ParseProfile(),
+    #[cfg(not(target_os = "linux"))]
     UnsupportedPlatform,
 }
 

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-rust-version.workspace = true
 publish = false
 
 [dependencies]

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -1,15 +1,18 @@
 [package]
 name = "rust-jemalloc-pprof-example"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 publish = false
 
 [dependencies]
-jemalloc_pprof = { path = ".." }
-tokio = { version = "1", features = ["full"] }
-axum = "0.8.9"
+jemalloc_pprof = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+axum = { workspace = true }
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.7", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"] }
+tikv-jemallocator = { workspace = true, features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"] }
 
 [features]
 flamegraph = ["jemalloc_pprof/flamegraph"]

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -59,13 +59,10 @@ pub async fn handle_get_heap_flamegraph() -> Result<impl IntoResponse, (StatusCo
 /// Checks whether jemalloc profiling is activated an returns an error response if not.
 fn require_profiling_activated(
     prof_ctl: &jemalloc_pprof::JemallocProfCtl,
-) -> Result<(), (axum::http::StatusCode, String)> {
+) -> Result<(), (StatusCode, String)> {
     if prof_ctl.activated() {
         Ok(())
     } else {
-        Err((
-            axum::http::StatusCode::FORBIDDEN,
-            "heap profiling not activated".into(),
-        ))
+        Err((StatusCode::FORBIDDEN, "heap profiling not activated".into()))
     }
 }

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -6,7 +6,7 @@ use axum::response::IntoResponse;
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 #[allow(non_upper_case_globals)]
-#[export_name = "malloc_conf"]
+#[unsafe(export_name = "malloc_conf")]
 pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
 
 #[tokio::main]

--- a/mappings/Cargo.toml
+++ b/mappings/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-rust-version.workspace = true
 description = "Get the mappings of a process (currently only on Linux)"
 homepage = "https://crates.io/crates/mappings"
 publish = true

--- a/mappings/Cargo.toml
+++ b/mappings/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "mappings"
-version = "0.7.2"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "Get the mappings of a process (currently only on Linux)"
-publish = true
-license = "Apache-2.0"
-repository = "https://github.com/polarsignals/rust-jemalloc-pprof"
 homepage = "https://crates.io/crates/mappings"
+publish = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,4 +16,4 @@ anyhow.workspace = true
 libc.workspace = true
 once_cell.workspace = true
 tracing.workspace = true
-util.workspace = true
+pprof_util.workspace = true

--- a/mappings/src/lib.rs
+++ b/mappings/src/lib.rs
@@ -247,11 +247,7 @@ mod enabled {
     /// Increases `p` as little as possible (including possibly 0)
     /// such that it becomes a multiple of `N`.
     pub const fn align_up<const N: usize>(p: usize) -> usize {
-        if p.is_multiple_of(N) {
-            p
-        } else {
-            p + (N - (p % N))
-        }
+        if p % N == 0 { p } else { p + (N - (p % N)) }
     }
 
     /// Asserts that the given pointer is valid.
@@ -268,7 +264,7 @@ mod enabled {
         let align = std::mem::align_of::<T>();
 
         assert!(!ptr.is_null());
-        assert!(address.is_multiple_of(align), "unaligned pointer");
+        assert!(address % align == 0, "unaligned pointer");
     }
 
     fn current_exe_from_dladdr() -> Result<PathBuf, anyhow::Error> {

--- a/mappings/src/lib.rs
+++ b/mappings/src/lib.rs
@@ -23,7 +23,7 @@ use std::path::PathBuf;
 use once_cell::sync::Lazy;
 use tracing::error;
 
-use util::{BuildId, Mapping};
+use pprof_util::{BuildId, Mapping};
 
 #[cfg(target_os = "linux")]
 mod enabled {
@@ -34,7 +34,7 @@ mod enabled {
 
     use anyhow::Context;
     use libc::{
-        c_int, c_void, dl_iterate_phdr, dl_phdr_info, size_t, Elf64_Word, PT_LOAD, PT_NOTE,
+        Elf64_Word, PT_LOAD, PT_NOTE, c_int, c_void, dl_iterate_phdr, dl_phdr_info, size_t,
     };
 
     use util::{BuildId, CastFrom};

--- a/mappings/src/lib.rs
+++ b/mappings/src/lib.rs
@@ -247,7 +247,11 @@ mod enabled {
     /// Increases `p` as little as possible (including possibly 0)
     /// such that it becomes a multiple of `N`.
     pub const fn align_up<const N: usize>(p: usize) -> usize {
-        if p % N == 0 { p } else { p + (N - (p % N)) }
+        if p.is_multiple_of(N) {
+            p
+        } else {
+            p + (N - (p % N))
+        }
     }
 
     /// Asserts that the given pointer is valid.
@@ -264,7 +268,7 @@ mod enabled {
         let align = std::mem::align_of::<T>();
 
         assert!(!ptr.is_null());
-        assert!(address % align == 0, "unaligned pointer");
+        assert!(address.is_multiple_of(align), "unaligned pointer");
     }
 
     fn current_exe_from_dladdr() -> Result<PathBuf, anyhow::Error> {

--- a/mappings/src/lib.rs
+++ b/mappings/src/lib.rs
@@ -34,10 +34,10 @@ mod enabled {
 
     use anyhow::Context;
     use libc::{
-        Elf64_Word, PT_LOAD, PT_NOTE, c_int, c_void, dl_iterate_phdr, dl_phdr_info, size_t,
+        c_int, c_void, dl_iterate_phdr, dl_phdr_info, size_t, Elf64_Word, PT_LOAD, PT_NOTE,
     };
 
-    use util::{BuildId, CastFrom};
+    use pprof_util::{BuildId, CastFrom};
 
     use crate::LoadedSegment;
 

--- a/mappings/src/lib.rs
+++ b/mappings/src/lib.rs
@@ -34,7 +34,7 @@ mod enabled {
 
     use anyhow::Context;
     use libc::{
-        c_int, c_void, dl_iterate_phdr, dl_phdr_info, size_t, Elf64_Word, PT_LOAD, PT_NOTE,
+        Elf64_Word, PT_LOAD, PT_NOTE, c_int, c_void, dl_iterate_phdr, dl_phdr_info, size_t,
     };
 
     use pprof_util::{BuildId, CastFrom};

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@ https://discourse.nixos.org/t/how-can-i-set-up-my-rust-programming-environment/4
 let
   rust_overlay = import (builtins.fetchTarball "https://github.com/oxalica/rust-overlay/archive/master.tar.gz");
   pkgs = import <nixpkgs> { overlays = [ rust_overlay ]; };
-  rustVersion = "1.74.1";
+  rustVersion = "1.85.0";
   rust = pkgs.rust-bin.stable.${rustVersion}.default.override {
     extensions = [
       "rust-src" # for rust-analyzer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,12 @@ use tempfile::NamedTempFile;
 use tikv_jemalloc_ctl::raw;
 use tokio::sync::Mutex;
 
-use util::parse_jeheap;
 #[cfg(feature = "flamegraph")]
-pub use util::FlamegraphOptions;
-pub use util::{BuildId, Mapping, ProfStartTime, StackProfile, StackProfileIter, WeightedStack};
+pub use pprof_util::FlamegraphOptions;
+use pprof_util::parse_jeheap;
+pub use pprof_util::{
+    BuildId, Mapping, ProfStartTime, StackProfile, StackProfileIter, WeightedStack,
+};
 
 /// Activate jemalloc profiling.
 pub async fn activate_jemalloc_profiling() {
@@ -152,7 +154,7 @@ impl JemallocProfCtl {
     /// Dump a profile into a temporary file and return it.
     pub fn dump(&mut self) -> anyhow::Result<std::fs::File> {
         let f = NamedTempFile::new()?;
-        let path = CString::new(f.path().as_os_str().as_encoded_bytes()).unwrap();
+        let path = CString::new(f.path().as_os_str().as_encoded_bytes())?;
 
         // SAFETY: "prof.dump" is documented as being writable and taking a C string as input:
         // http://jemalloc.net/jemalloc.3.html#prof.dump

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "pprof_util"
-version = "0.8.2"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 description = "various utilities for representing and manipulating profiling data"
 publish = true
-license = "Apache-2.0"
-repository = "https://github.com/polarsignals/rust-jemalloc-pprof"
 homepage = "https://crates.io/crates/pprof_util"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-rust-version.workspace = true
 description = "various utilities for representing and manipulating profiling data"
 publish = true
 homepage = "https://crates.io/crates/pprof_util"

--- a/util/src/cast.rs
+++ b/util/src/cast.rs
@@ -178,11 +178,7 @@ macro_rules! try_cast_from {
             fn try_cast_from(from: $from) -> Option<$to> {
                 let to = from as $to;
                 let inverse = to as $from;
-                if from == inverse {
-                    Some(to)
-                } else {
-                    None
-                }
+                if from == inverse { Some(to) } else { None }
             }
         }
     };

--- a/util/src/cast.rs
+++ b/util/src/cast.rs
@@ -15,8 +15,8 @@
 
 //! Cast utilities.
 
-use num::traits::bounds::UpperBounded;
 use num::Signed;
+use num::traits::bounds::UpperBounded;
 use std::error::Error;
 use std::fmt;
 use std::ops::Deref;
@@ -178,11 +178,7 @@ macro_rules! try_cast_from {
             fn try_cast_from(from: $from) -> Option<$to> {
                 let to = from as $to;
                 let inverse = to as $from;
-                if from == inverse {
-                    Some(to)
-                } else {
-                    None
-                }
+                if from == inverse { Some(to) } else { None }
             }
         }
     };

--- a/util/src/cast.rs
+++ b/util/src/cast.rs
@@ -178,7 +178,11 @@ macro_rules! try_cast_from {
             fn try_cast_from(from: $from) -> Option<$to> {
                 let to = from as $to;
                 let inverse = to as $from;
-                if from == inverse { Some(to) } else { None }
+                if from == inverse {
+                    Some(to)
+                } else {
+                    None
+                }
             }
         }
     };

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -414,39 +414,40 @@ pub fn parse_jeheap<R: BufRead>(
             addrs.reverse();
             cur_stack = Some(addrs);
         }
-        if words.len() > 2 && words[0] == "t*:" {
-            if let Some(addrs) = cur_stack.take() {
-                // The format here is e.g.:
-                // t*: 40274: 2822125696 [0: 0]
-                //
-                // "t*" means summary across all threads; someday we will support per-thread dumps but don't now.
-                // "40274" is the number of sampled allocations (`n_objs` here).
-                // On all released versions of jemalloc, "2822125696" is the total number of bytes in those allocations.
-                //
-                // To get the predicted number of total bytes from the sample, we need to un-bias it by following the logic in
-                // jeprof's `AdjustSamples`: https://github.com/jemalloc/jemalloc/blob/498f47e1ec83431426cdff256c23eceade41b4ef/bin/jeprof.in#L4064-L4074
-                //
-                // However, this algorithm is actually wrong: you actually need to unbias each sample _before_ you add them together, rather
-                // than adding them together first and then unbiasing the average allocation size. But the heap profile format in released versions of jemalloc
-                // does not give us access to each individual allocation, so this is the best we can do (and `jeprof` does the same).
-                //
-                // It usually seems to be at least close enough to being correct to be useful, but could be very wrong if for the same stack, there is a
-                // very large amount of variance in the amount of bytes allocated (e.g., if there is one allocation of 8 MB and 1,000,000 of 8 bytes)
-                //
-                // In the latest unreleased jemalloc sources from github, the issue is worked around by unbiasing the numbers for each sampled allocation,
-                // and then fudging them to maintain compatibility with jeprof's logic. So, once those are released and we start using them,
-                // this will become even more correct.
-                //
-                // For more details, see this doc: https://github.com/jemalloc/jemalloc/pull/1902
-                //
-                // And this gitter conversation between me (Brennan Vincent) and David Goldblatt: https://gitter.im/jemalloc/jemalloc?at=5f31b673811d3571b3bb9b6b
-                let n_objs: f64 = str::parse(words[1].trim_end_matches(':'))?;
-                let bytes_in_sampled_objs: f64 = str::parse(words[2])?;
-                let ratio = (bytes_in_sampled_objs / n_objs) / sampling_rate;
-                let scale_factor = 1.0 / (1.0 - (-ratio).exp());
-                let weight = bytes_in_sampled_objs * scale_factor;
-                profile.push_stack(WeightedStack { addrs, weight }, None);
-            }
+        if words.len() > 2
+            && words[0] == "t*:"
+            && let Some(addrs) = cur_stack.take()
+        {
+            // The format here is e.g.:
+            // t*: 40274: 2822125696 [0: 0]
+            //
+            // "t*" means summary across all threads; someday we will support per-thread dumps but don't now.
+            // "40274" is the number of sampled allocations (`n_objs` here).
+            // On all released versions of jemalloc, "2822125696" is the total number of bytes in those allocations.
+            //
+            // To get the predicted number of total bytes from the sample, we need to un-bias it by following the logic in
+            // jeprof's `AdjustSamples`: https://github.com/jemalloc/jemalloc/blob/498f47e1ec83431426cdff256c23eceade41b4ef/bin/jeprof.in#L4064-L4074
+            //
+            // However, this algorithm is actually wrong: you actually need to unbias each sample _before_ you add them together, rather
+            // than adding them together first and then unbiasing the average allocation size. But the heap profile format in released versions of jemalloc
+            // does not give us access to each individual allocation, so this is the best we can do (and `jeprof` does the same).
+            //
+            // It usually seems to be at least close enough to being correct to be useful, but could be very wrong if for the same stack, there is a
+            // very large amount of variance in the amount of bytes allocated (e.g., if there is one allocation of 8 MB and 1,000,000 of 8 bytes)
+            //
+            // In the latest unreleased jemalloc sources from github, the issue is worked around by unbiasing the numbers for each sampled allocation,
+            // and then fudging them to maintain compatibility with jeprof's logic. So, once those are released and we start using them,
+            // this will become even more correct.
+            //
+            // For more details, see this doc: https://github.com/jemalloc/jemalloc/pull/1902
+            //
+            // And this gitter conversation between me (Brennan Vincent) and David Goldblatt: https://gitter.im/jemalloc/jemalloc?at=5f31b673811d3571b3bb9b6b
+            let n_objs: f64 = str::parse(words[1].trim_end_matches(':'))?;
+            let bytes_in_sampled_objs: f64 = str::parse(words[2])?;
+            let ratio = (bytes_in_sampled_objs / n_objs) / sampling_rate;
+            let scale_factor = 1.0 / (1.0 - (-ratio).exp());
+            let weight = bytes_in_sampled_objs * scale_factor;
+            profile.push_stack(WeightedStack { addrs, weight }, None);
         }
     }
     if cur_stack.is_some() {

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -8,8 +8,8 @@ use std::path::PathBuf;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::bail;
-use flate2::write::GzEncoder;
 use flate2::Compression;
+use flate2::write::GzEncoder;
 use prost::Message;
 
 pub use cast::CastFrom;


### PR DESCRIPTION
This bumps the workspace to v0.9.0 and moves the shared package fields into workspace-level metadata so version, edition, license, repository, and rust-version stay in one place.

I also updated the member crates to use the shared workspace dependencies, aligned the internal utility crate references, and synced the README, shell.nix, and CI workflow with the new workspace setup.