### PR TITLE
Support macOS heap profiling and mappings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,3 +65,5 @@ symbolize = ["util/symbolize"]
 tokio = { version = "1", features = ["full"] }
 tikv-jemallocator = "0.7"
 axum = "0.8"
+flate2.workspace = true
+prost.workspace = true

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ This code was originally developed as part of [Materialize](https://github.com/M
 
 ## Requirements
 
-Currently, this library only supports Linux.
+This library supports profiling-enabled `jemalloc` on Unix platforms such as Linux and macOS.
+On Linux it exports shared-object mappings with GNU build IDs, and on macOS it exports the same
+mapping metadata using Mach-O image information plus UUID load commands. Other Unix platforms
+gracefully fall back to profiles without that extra mapping metadata.
 
 Furthermore, you must be able to switch your allocator to `jemalloc`.
 If you need to continue using the default system allocator for any reason,
@@ -171,8 +174,9 @@ Once the prerequisites are installed, the library can be built by
 running `make capi`. There are three files of
 interest:
 
-- The library itself, produced at
-  `target/release/libjemalloc_pprof.so`
+- The library itself, produced as a platform-specific shared library such as
+  `target/release/libjemalloc_pprof.so` on Linux or
+  `target/release/libjemalloc_pprof.dylib` on macOS
 - A header file, at `capi/include/jemalloc_pprof.h`
 - A manual page, at `capi/man/jemalloc_pprof.3`.
 

--- a/capi/Cargo.toml
+++ b/capi/Cargo.toml
@@ -13,3 +13,4 @@ util.workspace = true
 tempfile.workspace = true
 mappings.workspace = true
 errno.workspace = true
+tikv-jemalloc-ctl.workspace = true

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -14,7 +14,7 @@ pub const JP_FAILURE: c_int = -1;
 
 enum Error {
     Io(std::io::Error),
-    Mallctl,
+    Mallctl(c_int),
     ParseProfile(),
 }
 
@@ -25,8 +25,10 @@ impl From<std::io::Error> for Error {
 }
 
 impl From<tikv_jemalloc_ctl::Error> for Error {
-    fn from(_: tikv_jemalloc_ctl::Error) -> Self {
-        Self::Mallctl
+    fn from(err: tikv_jemalloc_ctl::Error) -> Self {
+        // SAFETY: `tikv_jemalloc_ctl::Error` is `repr(transparent)` over a nonzero C int.
+        let errno = unsafe { std::mem::transmute::<tikv_jemalloc_ctl::Error, c_int>(err) };
+        Self::Mallctl(errno)
     }
 }
 
@@ -67,7 +69,8 @@ pub unsafe extern "C" fn dump_jemalloc_pprof(buf_out: *mut *mut u8, n_out: *mut 
             set_errno(Errno(e.raw_os_error().expect("checked above")));
             return JP_FAILURE;
         }
-        Err(Error::Mallctl) => {
+        Err(Error::Mallctl(errno)) => {
+            set_errno(Errno(errno));
             return JP_FAILURE;
         }
         // TODO - maybe some of these can have errnos

--- a/capi/src/lib.rs
+++ b/capi/src/lib.rs
@@ -1,33 +1,20 @@
-use std::ffi::CString;
-use std::io::BufReader;
-use std::mem::size_of_val;
-use std::os::unix::ffi::OsStrExt;
 use std::ptr::null_mut;
 
 use errno::{set_errno, Errno};
-use libc::{c_char, c_int, c_void, size_t};
+use libc::{c_int, size_t};
 use mappings::MAPPINGS;
+use std::ffi::CString;
+use std::io::BufReader;
 use tempfile::NamedTempFile;
+use tikv_jemalloc_ctl::raw;
 use util::parse_jeheap;
 
 pub const JP_SUCCESS: c_int = 0;
 pub const JP_FAILURE: c_int = -1;
 
-#[link(name = "jemalloc")]
-extern "C" {
-    // int mallctl(const char *name, void *oldp, size_t *oldlenp, void *newp, size_t newlen);
-    fn mallctl(
-        name: *const c_char,
-        oldp: *mut c_void,
-        oldlenp: *mut size_t,
-        newp: *mut c_void,
-        newlen: size_t,
-    ) -> c_int;
-}
-
 enum Error {
     Io(std::io::Error),
-    Mallctl(c_int),
+    Mallctl,
     ParseProfile(),
 }
 
@@ -37,24 +24,18 @@ impl From<std::io::Error> for Error {
     }
 }
 
+impl From<tikv_jemalloc_ctl::Error> for Error {
+    fn from(_: tikv_jemalloc_ctl::Error) -> Self {
+        Self::Mallctl
+    }
+}
+
 fn dump_pprof_inner() -> Result<Vec<u8>, Error> {
     let f = NamedTempFile::new()?;
-    let path = CString::new(f.path().as_os_str().as_bytes().to_vec()).unwrap();
+    let path = CString::new(f.path().as_os_str().as_encoded_bytes()).expect("temp path is valid");
     // SAFETY: "prof.dump" is documented as being writable and taking a C string as input:
     // http://jemalloc.net/jemalloc.3.html#prof.dump
-    let pp = (&mut path.as_ptr()) as *mut _ as *mut _;
-    let ret = unsafe {
-        mallctl(
-            b"prof.dump\0" as *const _ as *const c_char,
-            null_mut(),
-            null_mut(),
-            pp,
-            size_of_val(&pp),
-        )
-    };
-    if ret != 0 {
-        return Err(Error::Mallctl(ret));
-    }
+    unsafe { raw::write(b"prof.dump\0", path.as_ptr()) }?;
 
     let dump_reader = BufReader::new(f);
     let profile =
@@ -83,11 +64,10 @@ pub unsafe extern "C" fn dump_jemalloc_pprof(buf_out: *mut *mut u8, n_out: *mut 
     let buf = match dump_pprof_inner() {
         Ok(buf) => buf,
         Err(Error::Io(e)) if e.raw_os_error().is_some() => {
-            set_errno(Errno(e.raw_os_error().unwrap()));
+            set_errno(Errno(e.raw_os_error().expect("checked above")));
             return JP_FAILURE;
         }
-        Err(Error::Mallctl(i)) => {
-            set_errno(Errno(i));
+        Err(Error::Mallctl) => {
             return JP_FAILURE;
         }
         // TODO - maybe some of these can have errnos

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -8,8 +8,11 @@ publish = false
 jemalloc_pprof = { path = ".." }
 tokio = { version = "1", features = ["full"] }
 axum = "0.8.9"
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
+[target.'cfg(all(not(target_env = "msvc"), not(target_os = "macos")))'.dependencies]
 tikv-jemallocator = { version = "0.7", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms", "background_threads"] }
+
+[target.'cfg(all(not(target_env = "msvc"), target_os = "macos"))'.dependencies]
+tikv-jemallocator = { version = "0.7", features = ["profiling", "stats", "unprefixed_malloc_on_supported_platforms"] }
 
 [features]
 flamegraph = ["jemalloc_pprof/flamegraph"]

--- a/mappings/Cargo.toml
+++ b/mappings/Cargo.toml
@@ -2,7 +2,7 @@
 name = "mappings"
 version = "0.7.2"
 edition = "2021"
-description = "Get the mappings of a process (currently only on Linux)"
+description = "Get the mappings of a process on Linux and macOS"
 publish = true
 license = "Apache-2.0"
 repository = "https://github.com/polarsignals/rust-jemalloc-pprof"

--- a/mappings/src/lib.rs
+++ b/mappings/src/lib.rs
@@ -81,7 +81,7 @@ mod enabled {
 
     use util::{BuildId, CastFrom};
 
-    use crate::{LoadedSegment, assert_pointer_valid};
+    use crate::{assert_pointer_valid, LoadedSegment};
 
     use super::SharedObject;
 

--- a/mappings/src/lib.rs
+++ b/mappings/src/lib.rs
@@ -289,7 +289,7 @@ mod enabled {
     /// Increases `p` as little as possible (including possibly 0)
     /// such that it becomes a multiple of `N`.
     pub const fn align_up<const N: usize>(p: usize) -> usize {
-        if p % N == 0 {
+        if p.is_multiple_of(N) {
             p
         } else {
             p + (N - (p % N))

--- a/mappings/src/lib.rs
+++ b/mappings/src/lib.rs
@@ -81,7 +81,7 @@ mod enabled {
 
     use util::{BuildId, CastFrom};
 
-    use crate::LoadedSegment;
+    use crate::{LoadedSegment, assert_pointer_valid};
 
     use super::SharedObject;
 

--- a/mappings/src/lib.rs
+++ b/mappings/src/lib.rs
@@ -13,17 +13,59 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! Linux-specific process introspection.
+//! Unix process introspection.
 
 //! Utility crate to extract information about the running process.
 //!
-//! Currently only works on Linux.
+//! Currently supports Linux and macOS.
+
+#[cfg(not(target_pointer_width = "64"))]
+compile_error!("this module only supports 64-bit targets");
+
 use std::path::PathBuf;
 
 use once_cell::sync::Lazy;
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 use tracing::error;
 
 use util::{BuildId, Mapping};
+
+fn build_mappings(objects: &[SharedObject]) -> Vec<Mapping> {
+    let mut mappings = Vec::new();
+    for object in objects {
+        for segment in &object.loaded_segments {
+            // Some platforms can report a negative slide for relocated images.
+            // Casting to usize preserves the two's complement bit pattern, so a
+            // wrapping add still yields the correct runtime start address.
+            let memory_start = object.base_address.wrapping_add(segment.memory_offset);
+            mappings.push(Mapping {
+                memory_start,
+                memory_end: memory_start + segment.memory_size,
+                memory_offset: segment.memory_offset,
+                file_offset: segment.file_offset,
+                pathname: object.path_name.clone(),
+                build_id: object.build_id.clone(),
+            });
+        }
+    }
+    mappings
+}
+
+/// Asserts that the given pointer is valid.
+///
+/// # Panics
+///
+/// Panics if the given pointer:
+///  * is a null pointer
+///  * is not properly aligned for `T`
+fn assert_pointer_valid<T>(ptr: *const T) {
+    #[allow(clippy::as_conversions)]
+    let address = ptr as usize;
+    let align = std::mem::align_of::<T>();
+
+    assert!(!ptr.is_null());
+    assert!(address.is_multiple_of(align), "unaligned pointer");
+}
 
 #[cfg(target_os = "linux")]
 mod enabled {
@@ -247,28 +289,11 @@ mod enabled {
     /// Increases `p` as little as possible (including possibly 0)
     /// such that it becomes a multiple of `N`.
     pub const fn align_up<const N: usize>(p: usize) -> usize {
-        if p.is_multiple_of(N) {
+        if p % N == 0 {
             p
         } else {
             p + (N - (p % N))
         }
-    }
-
-    /// Asserts that the given pointer is valid.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the given pointer:
-    ///  * is a null pointer
-    ///  * is not properly aligned for `T`
-    fn assert_pointer_valid<T>(ptr: *const T) {
-        // No other known way to convert a pointer to `usize`.
-        #[allow(clippy::as_conversions)]
-        let address = ptr as usize;
-        let align = std::mem::align_of::<T>();
-
-        assert!(!ptr.is_null());
-        assert!(address.is_multiple_of(align), "unaligned pointer");
     }
 
     fn current_exe_from_dladdr() -> Result<PathBuf, anyhow::Error> {
@@ -304,43 +329,231 @@ mod enabled {
     }
 }
 
-/// Mappings of the processes' executable and shared libraries.
-#[cfg(target_os = "linux")]
-pub static MAPPINGS: Lazy<Option<Vec<Mapping>>> = Lazy::new(|| {
-    /// Build a list of mappings for the passed shared objects.
-    fn build_mappings(objects: &[SharedObject]) -> Vec<Mapping> {
-        let mut mappings = Vec::new();
-        for object in objects {
-            for segment in &object.loaded_segments {
-                // I have observed that `memory_offset` can be negative on some very old
-                // versions of Linux (e.g. CentOS 7), so use wrapping add here.
-                let memory_start = object.base_address.wrapping_add(segment.memory_offset);
-                mappings.push(Mapping {
-                    memory_start,
-                    memory_end: memory_start + segment.memory_size,
-                    memory_offset: segment.memory_offset,
-                    file_offset: segment.file_offset,
-                    pathname: object.path_name.clone(),
-                    build_id: object.build_id.clone(),
-                });
-            }
-        }
-        mappings
+#[cfg(target_os = "macos")]
+#[allow(deprecated)]
+mod enabled {
+    use std::ffi::{CStr, OsStr};
+    use std::mem::size_of;
+    use std::os::unix::ffi::OsStrExt;
+    use std::path::PathBuf;
+
+    use anyhow::Context;
+    use libc::{
+        _dyld_get_image_header, _dyld_get_image_name, _dyld_get_image_vmaddr_slide,
+        _dyld_image_count, load_command, mach_header_64, segment_command_64, LC_SEGMENT_64,
+        MH_MAGIC_64, VM_PROT_EXECUTE, VM_PROT_READ,
+    };
+
+    use util::{BuildId, CastFrom};
+
+    use crate::{assert_pointer_valid, LoadedSegment, SharedObject};
+
+    const LC_UUID: u32 = 0x1b;
+
+    #[repr(C)]
+    struct UuidCommand {
+        cmd: u32,
+        cmdsize: u32,
+        uuid: [u8; 16],
     }
 
-    // SAFETY: We are on Linux
+    fn should_collect_segment(segment: &segment_command_64) -> bool {
+        segment.vmsize != 0 && (segment.initprot & (VM_PROT_READ | VM_PROT_EXECUTE)) != 0
+    }
+
+    pub unsafe fn collect_shared_objects() -> Result<Vec<SharedObject>, anyhow::Error> {
+        let image_count = unsafe { _dyld_image_count() };
+        let mut objects = Vec::with_capacity(usize::cast_from(image_count));
+
+        for image_index in 0..image_count {
+            let Some(object) = (unsafe { collect_image(image_index) })
+                .with_context(|| format!("failed to inspect loaded image {image_index}"))?
+            else {
+                continue;
+            };
+            objects.push(object);
+        }
+
+        Ok(objects)
+    }
+
+    unsafe fn collect_image(image_index: u32) -> Result<Option<SharedObject>, anyhow::Error> {
+        let header_ptr = unsafe { _dyld_get_image_header(image_index) };
+        if header_ptr.is_null() {
+            return Ok(None);
+        }
+
+        let header_ptr = header_ptr.cast::<mach_header_64>();
+        assert_pointer_valid(header_ptr);
+        let header = unsafe { header_ptr.as_ref() }.expect("pointer is valid");
+
+        if header.magic != MH_MAGIC_64 {
+            return Ok(None);
+        }
+
+        let path_name = match current_image_name(image_index)? {
+            Some(path) => path,
+            None if image_index == 0 => std::env::current_exe()
+                .context("failed to read the name of the current executable")?,
+            None => return Ok(None),
+        };
+
+        let base_address = {
+            let slide = unsafe { _dyld_get_image_vmaddr_slide(image_index) };
+            #[allow(clippy::as_conversions)]
+            {
+                slide as usize
+            }
+        };
+
+        let mut loaded_segments = Vec::new();
+        let mut build_id = None;
+        let mut remaining_cmd_bytes = usize::cast_from(header.sizeofcmds);
+        let mut cmd_ptr = unsafe { header_ptr.cast::<u8>().add(size_of::<mach_header_64>()) };
+
+        for _ in 0..header.ncmds {
+            if remaining_cmd_bytes < size_of::<load_command>() {
+                anyhow::bail!("truncated load commands");
+            }
+
+            let load_cmd = cmd_ptr.cast::<load_command>();
+            assert_pointer_valid(load_cmd);
+            let load_cmd = unsafe { load_cmd.as_ref() }.expect("pointer is valid");
+            let cmdsize = usize::cast_from(load_cmd.cmdsize);
+
+            if cmdsize < size_of::<load_command>() || cmdsize > remaining_cmd_bytes {
+                anyhow::bail!("invalid load command size {}", load_cmd.cmdsize);
+            }
+
+            match load_cmd.cmd {
+                LC_SEGMENT_64 => {
+                    if cmdsize < size_of::<segment_command_64>() {
+                        anyhow::bail!("truncated LC_SEGMENT_64 command");
+                    }
+
+                    let segment = cmd_ptr.cast::<segment_command_64>();
+                    assert_pointer_valid(segment);
+                    let segment = unsafe { segment.as_ref() }.expect("pointer is valid");
+
+                    if should_collect_segment(segment) {
+                        loaded_segments.push(LoadedSegment {
+                            file_offset: segment.fileoff,
+                            memory_offset: usize::cast_from(segment.vmaddr),
+                            memory_size: usize::cast_from(segment.vmsize),
+                        });
+                    }
+                }
+                LC_UUID if build_id.is_none() => {
+                    if cmdsize < size_of::<UuidCommand>() {
+                        anyhow::bail!("truncated LC_UUID command");
+                    }
+
+                    let uuid = cmd_ptr.cast::<UuidCommand>();
+                    assert_pointer_valid(uuid);
+                    let uuid = unsafe { uuid.as_ref() }.expect("pointer is valid");
+                    build_id = Some(BuildId(uuid.uuid.to_vec()));
+                }
+                _ => {}
+            }
+
+            cmd_ptr = unsafe { cmd_ptr.add(cmdsize) };
+            remaining_cmd_bytes -= cmdsize;
+        }
+
+        Ok(Some(SharedObject {
+            base_address,
+            path_name,
+            build_id,
+            loaded_segments,
+        }))
+    }
+
+    fn current_image_name(image_index: u32) -> Result<Option<PathBuf>, anyhow::Error> {
+        let name = unsafe { _dyld_get_image_name(image_index) };
+        if name.is_null() {
+            return Ok(None);
+        }
+
+        assert_pointer_valid(name);
+        let name = unsafe { CStr::from_ptr(name) };
+        if name.to_bytes().is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(OsStr::from_bytes(name.to_bytes()).into()))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use libc::{
+            segment_command_64, VM_PROT_EXECUTE, VM_PROT_NONE, VM_PROT_READ, VM_PROT_WRITE,
+        };
+
+        #[test]
+        fn filters_out_non_readable_and_non_executable_segments() {
+            let inaccessible = segment_command_64 {
+                cmd: 0,
+                cmdsize: 0,
+                segname: [0; 16],
+                vmaddr: 0,
+                vmsize: 4096,
+                fileoff: 0,
+                filesize: 0,
+                maxprot: VM_PROT_NONE,
+                initprot: VM_PROT_NONE,
+                nsects: 0,
+                flags: 0,
+            };
+            assert!(!super::should_collect_segment(&inaccessible));
+
+            let writable_only = segment_command_64 {
+                initprot: VM_PROT_WRITE,
+                ..inaccessible
+            };
+            assert!(!super::should_collect_segment(&writable_only));
+
+            let readable = segment_command_64 {
+                initprot: VM_PROT_READ,
+                ..inaccessible
+            };
+            assert!(super::should_collect_segment(&readable));
+
+            let executable = segment_command_64 {
+                initprot: VM_PROT_EXECUTE,
+                ..inaccessible
+            };
+            assert!(super::should_collect_segment(&executable));
+        }
+
+        #[test]
+        fn collects_macho_images_for_current_process() {
+            let objects =
+                unsafe { super::collect_shared_objects() }.expect("macOS image enumeration works");
+            assert!(!objects.is_empty());
+            assert!(objects
+                .iter()
+                .any(|object| !object.loaded_segments.is_empty()));
+            assert!(objects.iter().any(|object| object.build_id.is_some()));
+        }
+    }
+}
+
+/// Mappings of the processes' executable and shared libraries.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+pub static MAPPINGS: Lazy<Option<Vec<Mapping>>> = Lazy::new(|| {
+    // SAFETY: each platform-specific implementation documents its preconditions.
     match unsafe { enabled::collect_shared_objects() } {
         Ok(objects) => Some(build_mappings(&objects)),
         Err(err) => {
-            error!("build ID fetching failed: {err}");
+            error!("shared object metadata collection failed: {err}");
             None
         }
     }
 });
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(not(any(target_os = "linux", target_os = "macos")))]
 pub static MAPPINGS: Lazy<Option<Vec<Mapping>>> = Lazy::new(|| {
-    error!("build ID fetching is only supported on Linux");
+    tracing::error!("build ID fetching is only supported on Linux or macOS");
     None
 });
 

--- a/mappings/src/lib.rs
+++ b/mappings/src/lib.rs
@@ -19,7 +19,10 @@
 //!
 //! Currently supports Linux and macOS.
 
-#[cfg(not(target_pointer_width = "64"))]
+#[cfg(all(
+    any(target_os = "linux", target_os = "macos"),
+    not(target_pointer_width = "64")
+))]
 compile_error!("this module only supports 64-bit targets");
 
 use std::path::PathBuf;
@@ -40,7 +43,7 @@ fn build_mappings(objects: &[SharedObject]) -> Vec<Mapping> {
             let memory_start = object.base_address.wrapping_add(segment.memory_offset);
             mappings.push(Mapping {
                 memory_start,
-                memory_end: memory_start + segment.memory_size,
+                memory_end: memory_start.wrapping_add(segment.memory_size),
                 memory_offset: segment.memory_offset,
                 file_offset: segment.file_offset,
                 pathname: object.path_name.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,3 +194,63 @@ impl JemallocProfCtl {
         profile.to_flamegraph(opts)
     }
 }
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use std::io::Read;
+
+    use flate2::read::GzDecoder;
+    use prost::Message;
+
+    use super::{StackProfile, MAPPINGS};
+
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, Message)]
+    struct ProfileProto {
+        #[prost(string, repeated, tag = "6")]
+        string_table: Vec<String>,
+        #[prost(message, repeated, tag = "3")]
+        mapping: Vec<MappingProto>,
+    }
+
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, Message)]
+    struct MappingProto {
+        #[prost(int64, tag = "6")]
+        build_id: i64,
+    }
+
+    #[test]
+    fn pprof_output_contains_macos_uuid_build_id_string() {
+        let mapping = MAPPINGS
+            .as_ref()
+            .expect("macOS mappings are available")
+            .iter()
+            .find(|mapping| mapping.build_id.is_some())
+            .cloned()
+            .expect("loaded macOS image exposes a UUID");
+
+        let expected_build_id = mapping
+            .build_id
+            .as_ref()
+            .expect("checked above")
+            .to_string();
+        let profile = StackProfile {
+            annotations: Vec::new(),
+            stacks: Vec::new(),
+            mappings: vec![mapping],
+        };
+        let encoded = profile.to_pprof(("inuse_space", "bytes"), ("space", "bytes"), None);
+
+        let mut decoded = Vec::new();
+        GzDecoder::new(encoded.as_slice())
+            .read_to_end(&mut decoded)
+            .expect("pprof payload is valid gzip");
+        let profile =
+            ProfileProto::decode(decoded.as_slice()).expect("pprof payload is valid protobuf");
+
+        let build_id_idx =
+            usize::try_from(profile.mapping[0].build_id).expect("positive build id index");
+        assert_eq!(profile.string_table[build_id_idx], expected_build_id);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -249,8 +249,18 @@ mod tests {
         let profile =
             ProfileProto::decode(decoded.as_slice()).expect("pprof payload is valid protobuf");
 
-        let build_id_idx =
-            usize::try_from(profile.mapping[0].build_id).expect("positive build id index");
-        assert_eq!(profile.string_table[build_id_idx], expected_build_id);
+        let found_expected_build_id = profile.mapping.iter().any(|mapping| {
+            let Ok(build_id_idx) = usize::try_from(mapping.build_id) else {
+                return false;
+            };
+            profile
+                .string_table
+                .get(build_id_idx)
+                .is_some_and(|build_id| build_id == &expected_build_id)
+        });
+        assert!(
+            found_expected_build_id,
+            "pprof payload should retain the expected macOS UUID"
+        );
     }
 }


### PR DESCRIPTION
## Summary

This PR adds macOS support for jemalloc heap profiling metadata and profile export.

It extends shared-object mapping collection to Mach-O images, records UUID build IDs for macOS mappings, and keeps the exported mapping set focused on readable or executable segments. It also updates the C API to use `tikv-jemalloc-ctl` for profile dumping so the same profile-export path works on macOS, and adjusts the example allocator configuration to avoid macOS-only background thread warnings.

## Why

The existing code path only supported Linux mappings, and the C API path depended on a Linux-specific jemalloc linkage strategy. That meant macOS users could sometimes get partial local results, but not a properly supported and tested profiling flow.

## Validation

- `cargo clippy --workspace --all-features -- -D warnings`
- `cargo test --workspace --all-features`

## Notes

This PR also adds macOS-specific tests to validate:

- Mach-O mapping collection returns UUID-backed mappings
- exported macOS mappings are limited to readable or executable segments
- generated pprof payloads retain the macOS UUID build ID string
